### PR TITLE
Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -389,3 +389,6 @@ FodyWeavers.xsd
 
 # Solution ignoring
 *.sln
+
+# Test Files
+build-copy.ps1

--- a/DiscordApi.cs
+++ b/DiscordApi.cs
@@ -73,6 +73,11 @@ namespace DiscordConnector
 
         internal static void SendSerializedJson(string serializedJson)
         {
+            if (string.IsNullOrEmpty(Plugin.StaticConfig.WebHookURL))
+            {
+                Plugin.StaticLogger.LogInfo("Not sending message, no webhook set.");
+                return;
+            }
             Plugin.StaticLogger.LogDebug($"Trying webhook with payload: {serializedJson}");
             // Responsible for sending a JSON string to the webhook.
             byte[] byteArray = Encoding.UTF8.GetBytes(serializedJson);

--- a/Metadata/CHANGELOG.md
+++ b/Metadata/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A full changelog for reference.
 
+### Version 0.7.1
+
+Added config option to ignore players when sending shout messages to Discord.
+
 ### Version 0.7.0
 
 Fixes:

--- a/Metadata/README.md
+++ b/Metadata/README.md
@@ -33,6 +33,10 @@ Connect your Valheim server (dedicated or served from the game itself) to a Disc
 Full changelog history available on the
 [Github repository](https://github.com/nwesterhausen/valheim-discordconnector/blob/main/Metadata/CHANGELOG.md).
 
+### Version 0.7.1
+
+Added config option to ignore players when sending shout messages to Discord.
+
 ### Version 0.7.0
 
 Fixes:

--- a/Metadata/manifest.json
+++ b/Metadata/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "DiscordConnector",
-  "version_number": "0.7.0",
+  "version_number": "0.7.1",
   "website_url": "https://github.com/nwesterhausen/valheim-discordconnector",
   "description": "Connects your Valheim server to a Discord webhook.",
   "dependencies": ["denikson-BepInExPack_Valheim-5.4.1600"]

--- a/Patches.cs
+++ b/Patches.cs
@@ -20,6 +20,15 @@ namespace DiscordConnector.Patches
                     );
                 }
             }
+            private static void Prefix(ref ZNet __instance)
+            {
+                if (Plugin.StaticConfig.LaunchMessageEnabled)
+                {
+                    DiscordApi.SendMessage(
+                        Plugin.StaticConfig.LaunchMessage
+                    );
+                }
+            }
         }
 
         [HarmonyPatch(typeof(ZNet), nameof(ZNet.Shutdown))]
@@ -120,9 +129,9 @@ namespace DiscordConnector.Patches
             {
                 if (Plugin.StaticConfig.ChatMessageEnabled)
                 {
-                    if (Plugin.StaticConfig.MutedPlayers.IndexOf(user) < 0)
+                    if (Plugin.StaticConfig.MutedPlayers.IndexOf(user) >= 0)
                     {
-                        Plugin.StaticLogger.LogInfo($"Ignored shout from user on muted list. User: {user} Shout: {text}");
+                        Plugin.StaticLogger.LogInfo($"Ignored shout from user on muted list. User: {user} Shout: {text}. Index {Plugin.StaticConfig.MutedPlayers.IndexOf(user)}");
                         return;
                     }
                     switch (type)

--- a/Patches.cs
+++ b/Patches.cs
@@ -120,6 +120,11 @@ namespace DiscordConnector.Patches
             {
                 if (Plugin.StaticConfig.ChatMessageEnabled)
                 {
+                    if (Plugin.StaticConfig.MutedPlayers.IndexOf(user) < 0)
+                    {
+                        Plugin.StaticLogger.LogInfo($"Ignored shout from user on muted list. User: {user} Shout: {text}");
+                        return;
+                    }
                     switch (type)
                     {
                         case Talker.Type.Ping:

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -24,14 +24,6 @@ namespace DiscordConnector
             {
                 StaticLogger.LogInfo("Not running on a dedicated server, some features may break -- please report them!");
             }
-            else if (StaticConfig.LaunchMessageEnabled)
-            {
-
-                DiscordApi.SendMessage(
-                    StaticConfig.LaunchMessage
-                );
-
-            }
 
             if (string.IsNullOrEmpty(StaticConfig.WebHookURL))
             {

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using BepInEx.Configuration;
 
 namespace DiscordConnector
@@ -16,6 +17,7 @@ namespace DiscordConnector
         // Discord Settings
         private ConfigEntry<string> webhookUrl;
         private ConfigEntry<bool> discordEmbedMessagesToggle;
+        private ConfigEntry<string> mutedDiscordUserlist;
 
         // Logged Information Toggles
         private ConfigEntry<bool> serverLaunchToggle;
@@ -52,6 +54,8 @@ namespace DiscordConnector
         {
             PluginConfig.config = config;
             LoadConfig();
+
+            MutedPlayers = new List<string>(mutedDiscordUserlist.Value.Split(','));
         }
 
         public void LoadConfig()
@@ -67,6 +71,12 @@ namespace DiscordConnector
                 false,
                 "Enable this setting to use embeds in the messages sent to Discord." + Environment.NewLine +
                 "NOTE: Some things may not work as expected with this enabled. Report any weirdness!");
+
+            mutedDiscordUserlist = config.Bind<string>(DISCORD_SETTINGS,
+                "Ignored Players",
+                "",
+                "It may be that you have some players that you never want to send Discord messages for. Adding a player name to this list will ignore them." + Environment.NewLine +
+                "Format should be a comma-separated list: Stuart,John McJohnny,Weird-name1");
 
             // Message Toggles
 
@@ -310,5 +320,6 @@ namespace DiscordConnector
                 return choices[selection];
             }
         }
+        public List<string> MutedPlayers;
     }
 }

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -8,6 +8,8 @@ namespace DiscordConnector
     {
         public static ConfigFile config;
 
+        private static List<String> mutedPlayers;
+
         // config header strings
         private const string DISCORD_SETTINGS = "Discord Settings";
         private const string NOTIFICATION_SETTINGS = "Notification Settings";
@@ -55,7 +57,7 @@ namespace DiscordConnector
             PluginConfig.config = config;
             LoadConfig();
 
-            MutedPlayers = new List<string>(mutedDiscordUserlist.Value.Split(','));
+            mutedPlayers = new List<string>(mutedDiscordUserlist.Value.Split(';'));
         }
 
         public void LoadConfig()
@@ -76,7 +78,7 @@ namespace DiscordConnector
                 "Ignored Players",
                 "",
                 "It may be that you have some players that you never want to send Discord messages for. Adding a player name to this list will ignore them." + Environment.NewLine +
-                "Format should be a comma-separated list: Stuart,John McJohnny,Weird-name1");
+                "Format should be a semicolon-separated list: Stuart;John McJohnny;Weird-name1");
 
             // Message Toggles
 
@@ -320,6 +322,6 @@ namespace DiscordConnector
                 return choices[selection];
             }
         }
-        public List<string> MutedPlayers;
+        public List<string> MutedPlayers => mutedPlayers;
     }
 }

--- a/PluginInfo.cs
+++ b/PluginInfo.cs
@@ -17,7 +17,7 @@ namespace DiscordConnector
     {
         public const string PLUGIN_ID = "games.nwest.valheim.discordconnector";
         public const string PLUGIN_NAME = "Valheim Discord Connector";
-        public const string PLUGIN_VERSION = "0.7.0";
+        public const string PLUGIN_VERSION = "0.7.1";
         public const string PLUGIN_REPO_SHORT = "github: nwesterhausen/valheim-discordconnector";
         public const string PLUGIN_AUTHOR = "Nicholas Westerhausen";
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Discord Connector
 
-Connect your Valheim server to a Discord Webhook. ([How to get a webhook](Metadata/HowtoGuide.md))
+Connect your Valheim server to a Discord Webhook. ([How to get a webhook](Metadata/HowtoGuide.md)). This plugin is largely based on [valheim-discord-notifier](https://github.com/aequasi/valheim-discord-notifier), but this plugin supports randomized messages, muting players, and Discord message embeds.
 
 Plugin available on [Thunderstore.io](https://valheim.thunderstore.io/package/nwesterhausen/DiscordConnector/) 
 or [NexusMods](https://www.nexusmods.com/valheim/mods/1551/).
@@ -40,3 +40,5 @@ Thanks for the helpful contributions!
 
 - @Digitalroot
 - @nwesterhausen
+
+Thanks for an excellent original plugin @aequasi!


### PR DESCRIPTION
- config option to ignore players when sending messages to discord 
- Moved "Server starting up" message to prefix the LoadWorld instead of when the plugin is loaded.