### PR TITLE
:pencil: fix wording on config files

### DIFF
--- a/src/Config/MainConfig.cs
+++ b/src/Config/MainConfig.cs
@@ -1,9 +1,8 @@
-// MAIN CONFIG
 using System;
 using System.Collections.Generic;
 using BepInEx.Configuration;
 
-namespace DiscordConnector
+namespace DiscordConnector.Config
 {
     internal class MainConfig
     {
@@ -42,8 +41,7 @@ namespace DiscordConnector
             discordEmbedMessagesToggle = config.Bind<bool>(MAIN_SETTINGS,
                 "Use fancier discord messages",
                 false,
-                "Enable this setting to use embeds in the messages sent to Discord." + Environment.NewLine +
-                "NOTE: Some things may not work as expected with this enabled. Report any weirdness!");
+                "Enable this setting to use embeds in the messages sent to Discord. Currently this will affect the position details for the messages.");
 
             mutedDiscordUserlist = config.Bind<string>(MAIN_SETTINGS,
                 "Ignored Players",
@@ -59,18 +57,18 @@ namespace DiscordConnector
             colectStatsToggle = config.Bind<bool>(MAIN_SETTINGS,
                 "Collect Player Stats",
                 true,
-                "Disable this setting to disable all stat collections and notifications. (Overwrites any individual setting.)");
+                "Disable this setting to disable all stat collection. (Overwrites any individual setting.)");
 
             statsAnnouncementToggle = config.Bind<bool>(MAIN_SETTINGS,
                 "Periodic Player Stats Notifications",
                 false,
-                "If enabled, periodically send a leaderboard or of top player stats to Discord." + Environment.NewLine +
+                "Disable this setting to disable all stat announcements (i.e. leader board messages). (Overwrites any individual setting.)" + Environment.NewLine +
                 "EX: Top Player Deaths: etc etc Top Player Joins: etc etc");
 
             statsAnnouncementPeriod = config.Bind<int>(MAIN_SETTINGS,
                 "Player Stats Notifications Period",
                 600,
-                "Set the number of minutes between a leaderboard announcement sent to discord." + Environment.NewLine +
+                "Set the number of minutes between a leader board announcement sent to discord." + Environment.NewLine +
                 "This time starts when the server is started. Default is set to 10 hours (600 mintues).");
 
             announcePlayerFirsts = config.Bind<bool>(MAIN_SETTINGS,
@@ -90,7 +88,7 @@ namespace DiscordConnector
             jsonString += $"\"ignoredPlayers\":\"{mutedDiscordUserlist.Value}\"";
             jsonString += "},";
             jsonString += $"\"periodicLeaderboardEnabled\":\"{StatsAnnouncementEnabled}\",";
-            jsonString += $"\"periodicLeaderabordPeriodSeconds\":{StatsAnnouncementPeriod},";
+            jsonString += $"\"periodicLeaderboardPeriodSeconds\":{StatsAnnouncementPeriod},";
             jsonString += $"\"colectStatsEnabled\":\"{CollectStatsEnabled}\",";
             jsonString += $"\"sendPositionsEnabled\":\"{SendPositionsEnabled}\",";
             jsonString += $"\"announcePlayerFirsts\":\"{AnnouncePlayerFirsts}\"";

--- a/src/Config/MessagesConfig.cs
+++ b/src/Config/MessagesConfig.cs
@@ -1,13 +1,13 @@
 using System;
 using BepInEx.Configuration;
 
-namespace DiscordConnector
+namespace DiscordConnector.Config
 {
     internal class MessagesConfig
     {
         private static ConfigFile config;
 
-        public static string ConfigExention = "messages";
+        public static string ConfigExtension = "messages";
 
         // config header strings
         private const string SERVER_MESSAGES = "Messages.Server";
@@ -49,25 +49,23 @@ namespace DiscordConnector
                 "Server is starting up.",
                 "Set the message that will be sent when the server starts up." + Environment.NewLine +
                 "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'" + Environment.NewLine +
-                "Random choice example: 'Server is starting;Server beginning to load'");
+                "Random choice example: Server is starting;Server beginning to load");
 
             serverLoadedMessage = config.Bind<string>(SERVER_MESSAGES,
                 "Server Started Message",
                 "Server has started!",
                 "Set the message that will be sent when the server has loaded the map and is ready for connections." + Environment.NewLine +
-                "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'" + Environment.NewLine +
-                "Random choice example: 'Server has started;Server ready!'");
+                "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'");
 
             serverStopMessage = config.Bind<string>(SERVER_MESSAGES,
                 "Server Stop Message",
                 "Server is stopping.",
                 "Set the message that will be sent when the server shuts down." + Environment.NewLine +
-                "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'" + Environment.NewLine +
-                "Random choice example: 'Server stopping;Valheim signing off!'");
+                "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'");
 
             serverShutdownMessage = config.Bind<string>(SERVER_MESSAGES,
                 "Server Shutdown Message",
-                "Server has stoped!",
+                "Server has stopped!",
                 "Set the message that will be sent when the server finishes shutting down." + Environment.NewLine +
                 "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'");
 
@@ -76,21 +74,19 @@ namespace DiscordConnector
                 "%PLAYER_NAME% has joined.",
                 "Set the message that will be sent when a player joins the server" + Environment.NewLine +
                 "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'" + Environment.NewLine +
-                "Random choice example: '%PLAYER_NAME% has joined;%PLAYER_NAME% awakens;%PLAYER_NAME% arrives'");
+                "Random choice example: %PLAYER_NAME% has joined;%PLAYER_NAME% awakens;%PLAYER_NAME% arrives");
 
             playerDeathMessage = config.Bind<string>(PLAYER_MESSAGES,
                 "Player Death Message",
                 "%PLAYER_NAME% has died.",
                 "Set the message that will be sent when a player dies." + Environment.NewLine +
-                "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'" + Environment.NewLine +
-                "Random choice example: '%PLAYER_NAME% has died;%PLAYER_NAME% passed on'");
+                "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'");
 
             playerLeaveMessage = config.Bind<string>(PLAYER_MESSAGES,
                 "Player Leave Message",
                 "%PLAYER_NAME% has left.",
                 "Set the message that will be sent when a player leaves the server." + Environment.NewLine +
-                "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'" + Environment.NewLine +
-                "Random choice example: '%PLAYER_NAME% has left;%PLAYER_NAME% has moved on;%PLAYER_NAME% returns to dreams'");
+                "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'");
 
             playerPingMessage = config.Bind<string>(PLAYER_MESSAGES,
                 "Player Ping Message",
@@ -131,7 +127,7 @@ namespace DiscordConnector
             playerFirstShoutMessage = config.Bind<string>(PLAYER_FIRSTS_MESSAGES,
                 "Player First Shout Message",
                 "%PLAYER_NAME% shouts for the first time.",
-                "Set the message that will be sent when a player shouts on the server." + Environment.NewLine +
+                "Set the message that will be sent when a player shouts on the server. %SHOUT% works in this message to include what was shouted." + Environment.NewLine +
                 "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'");
 
             config.Save();

--- a/src/Config/PluginConfig.cs
+++ b/src/Config/PluginConfig.cs
@@ -1,7 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
 using BepInEx.Configuration;
+using DiscordConnector.Config;
 
 namespace DiscordConnector
 {
@@ -14,8 +13,8 @@ namespace DiscordConnector
         public PluginConfig(ConfigFile config)
         {
             // Set up the config file paths
-            string messageConfigFilename = $"{PluginInfo.PLUGIN_ID}-{MessagesConfig.ConfigExention}.cfg";
-            string togglesConfigFilename = $"{PluginInfo.PLUGIN_ID}-{TogglesConfig.ConfigExention}.cfg";
+            string messageConfigFilename = $"{PluginInfo.PLUGIN_ID}-{MessagesConfig.ConfigExtension}.cfg";
+            string togglesConfigFilename = $"{PluginInfo.PLUGIN_ID}-{TogglesConfig.ConfigExtension}.cfg";
             string messagesConfigPath = System.IO.Path.Combine(BepInEx.Paths.ConfigPath, messageConfigFilename);
             string togglesConfigPath = System.IO.Path.Combine(BepInEx.Paths.ConfigPath, togglesConfigFilename);
 

--- a/src/Config/TogglesConfig.cs
+++ b/src/Config/TogglesConfig.cs
@@ -1,12 +1,11 @@
-using System;
 using BepInEx.Configuration;
 
-namespace DiscordConnector
+namespace DiscordConnector.Config
 {
     internal class TogglesConfig
     {
         private static ConfigFile config;
-        public static string ConfigExention = "toggles";
+        public static string ConfigExtension = "toggles";
 
         // Config Header Strings
         private const string MESSAGES_TOGGLES = "Toggles.Messages";
@@ -64,49 +63,39 @@ namespace DiscordConnector
             serverLaunchToggle = config.Bind<bool>(MESSAGES_TOGGLES,
                 "Server Launch Notifications",
                 true,
-                "If enabled, this will send a message to Discord when the server launches (and the plugin is loaded)." + Environment.NewLine +
-                "EX: Server has started. | Server has stopped.");
+                "If enabled, this will send a message to Discord when the server launches.");
             serverLoadedToggle = config.Bind<bool>(MESSAGES_TOGGLES,
                 "Server Loaded Notifications",
                 true,
-                "If enabled, this will send a message to Discord when the server has loaded the map and is ready for connections." + Environment.NewLine +
-                "EX: Server has started. | Server has stopped.");
+                "If enabled, this will send a message to Discord when the server has loaded the map and is ready for connections.");
             serverStopToggle = config.Bind<bool>(MESSAGES_TOGGLES,
                 "Server Stopping Notifications",
                 true,
-                "If enabled, this will send a message to Discord when the server begins stopping." + Environment.NewLine +
-                "EX: Server is stopping.");
+                "If enabled, this will send a message to Discord when the server begins shut down.");
             serverShutdownToggle = config.Bind<bool>(MESSAGES_TOGGLES,
                 "Server Shutdown Notifications",
                 true,
-                "If enabled, this will send a message to Discord when the server has shut down." + Environment.NewLine +
-                "EX: Server has stopped.");
+                "If enabled, this will send a message to Discord when the server has shut down.");
             chatShoutToggle = config.Bind<bool>(MESSAGES_TOGGLES,
                 "Chat Shout Messages Notifications",
                 true,
-                "If enabled, this will send a message to Discord when a player joins the server." + Environment.NewLine +
-                "EX: Nick shouted \"Hey you!\"");
+                "If enabled, this will send a message to Discord when a player shouts on the server.");
             chatPingToggle = config.Bind<bool>(MESSAGES_TOGGLES,
                 "Ping Notifications",
                 true,
-                "If enabled, include a position with the arrival message." + Environment.NewLine +
-                "If the top-level chat notifications are disabled, that will disable these messages." + Environment.NewLine +
-                "EX: Nick pinged the map!");
+                "If enabled, this will send a message to Discord when a player pings on the map.");
             playerJoinToggle = config.Bind<bool>(MESSAGES_TOGGLES,
                 "Player Join Notifications",
                 true,
-                "If enabled, this will send a message to Discord when a player joins the server." + Environment.NewLine +
-                "EX: Player has joined");
+                "If enabled, this will send a message to Discord when a player joins the server.");
             playerDeathToggle = config.Bind<bool>(MESSAGES_TOGGLES,
                 "Player Death Notifications",
                 true,
-                "If enabled, this will send a message to Discord when a player dies on the server." + Environment.NewLine +
-                "EX: Player has died");
+                "If enabled, this will send a message to Discord when a player dies on the server.");
             playerLeaveToggle = config.Bind<bool>(MESSAGES_TOGGLES,
                 "Player Leave Notifications",
                 true,
-                "If enabled, this will send a message to Discord when a player leaves the server." + Environment.NewLine +
-                "EX: Player has left.");
+                "If enabled, this will send a message to Discord when a player leaves the server.");
 
             // Position Toggles
             playerJoinPosToggle = config.Bind<bool>(POSITION_TOGGLES,
@@ -122,76 +111,75 @@ namespace DiscordConnector
                 true,
                 "If enabled, this will include the coordinates of the player when they die.");
             chatPingPosToggle = config.Bind<bool>(POSITION_TOGGLES,
-                "Ping Notificiations Include Position",
+                "Ping Notifications Include Position",
                 true,
                 "If enabled, includes the coordinates of the ping.");
             chatShoutPosToggle = config.Bind<bool>(POSITION_TOGGLES,
                 "Chat Shout Messages Position Notifications",
                 false,
-                "If enabled, include a position with the arrival message." + Environment.NewLine +
-                "EX: Nick shouted \"Hey you!\" (at -124, 81.4, -198.9)");
+                "If enabled, this will include the coordinates of the player when they shout.");
 
             // Statistic Settings
             collectStatsDeaths = config.Bind<bool>(STATS_TOGGLES,
                 "Collect and Send Player Death Stats",
                 true,
-                "If enabled, will collect and enable sending player death statistics.");
+                "If enabled, will allow collection of the number of times a player has died.");
             collectStatsJoins = config.Bind<bool>(STATS_TOGGLES,
                 "Collect and Send Player Join Stats",
                 true,
-                "If enabled, will collect and enable sending stat announcements for how many times a player has joined the game.");
+                "If enabled, will allow collection of how many times a player has joined the game.");
             collectStatsLeaves = config.Bind<bool>(STATS_TOGGLES,
                 "Collect and Send Player Leave Stats",
                 true,
-                "If enabled, will collect and enable sending stat announcements for how many times a player has left the game.");
+                "If enabled, will allow collection of how many times a player has left the game.");
             collectStatsPings = config.Bind<bool>(STATS_TOGGLES,
                 "Collect and Send Player Ping Stats",
                 true,
-                "If enabled, will collect and enable sending stat announcements for number of pings made by a player.");
+                "If enabled, will allow collection of the number of pings made by a player.");
             collectStatsShouts = config.Bind<bool>(STATS_TOGGLES,
                 "Collect and Send Player Shout Stats",
                 true,
-                "If enabled, will collect and enable sending stat announcements for number of times a player has shouted.");
+                "If enabled, will allow collection of the number of times a player has shouted.");
 
             // Leaderboard
             sendDeathsLeaderboard = config.Bind<bool>(LEADERBOARD_TOGGLES,
                 "Send Periodic Leaderboard for Player Deaths",
                 true,
-                "If enabled (and leaderboards are enabled), will send a leaderboard for player deaths at the interval.");
+                "If enabled, will send a leaderboard for player deaths at the interval.");
             sendPingsLeaderboard = config.Bind<bool>(LEADERBOARD_TOGGLES,
                 "Send Periodic Leaderboard for Player Pings",
                 false,
-                "If enabled (and leaderboards are enabled), will send a leaderboard for player pings at the interval.");
+                "If enabled, will send a leaderboard for player pings at the interval.");
             sendSessionLeaderboard = config.Bind<bool>(LEADERBOARD_TOGGLES,
                 "Send Periodic Leaderboard for Player Sessions",
                 false,
-                "If enabled (and leaderboards are enabled), will send a leaderboard for player sessions at the interval.");
+                "If enabled, will send a leaderboard for player sessions at the interval.");
             sendShoutsLeaderboard = config.Bind<bool>(LEADERBOARD_TOGGLES,
                 "Send Periodic Leaderboard for Player Shouts",
                 false,
-                "If enabled (and leaderboards are enabled), will send a leaderboard for player shouts at the interval.");
+                "If enabled, will send a leaderboard for player shouts at the interval.");
 
             // Player Firsts
             announcePlayerFirstDeath = config.Bind<bool>(PLAYER_FIRSTS_TOGGLES,
                 "Send a Message for the First Death of a Player",
                 true,
-                "If enabled (and player-first anouncements are enabled), will send an extra message on a player's first death.");
+                "If enabled, this will send an extra message on a player's first death.");
             announcePlayerFirstJoin = config.Bind<bool>(PLAYER_FIRSTS_TOGGLES,
                 "Send a Message for the First Join of a Player",
                 true,
-                "If enabled (and player-first anouncements are enabled), will send an extra message on a player's first join to the server.");
+                "If enabled, this will send an extra message on a player's first join to the server.");
             announcePlayerFirstLeave = config.Bind<bool>(PLAYER_FIRSTS_TOGGLES,
                 "Send a Message for the First Leave of a Player",
                 false,
-                "If enabled (and player-first anouncements are enabled), will send an extra message on a player's first leave from the server.");
+                "If enabled, this will send an extra message on a player's first leave from the server.");
             announcePlayerFirstPing = config.Bind<bool>(PLAYER_FIRSTS_TOGGLES,
                 "Send a Message for the First Ping of a Player",
                 false,
-                "If enabled (and player-first anouncements are enabled), will send an extra message on a player's first ping.");
+                "If enabled, this will send an extra message on a player's first ping.");
             announcePlayerFirstShout = config.Bind<bool>(PLAYER_FIRSTS_TOGGLES,
                 "Send a Message for the First Shout of a Player",
                 false,
-                "If enabled (and player-first anouncements are enabled), will send an extra message on a player's first shout.");
+                "If enabled, this will send an extra message on a player's first shout.");
 
             config.Save();
         }

--- a/src/Patches/ChatPatches.cs
+++ b/src/Patches/ChatPatches.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using HarmonyLib;
 using UnityEngine;
 
@@ -96,7 +95,7 @@ namespace DiscordConnector.Patches
                             }
                             if (Plugin.StaticConfig.AnnouncePlayerFirstShoutEnabled && Plugin.StaticRecords.Retrieve(Categories.Shout, user) == 0)
                             {
-                                DiscordApi.SendMessage(Plugin.StaticConfig.PlayerFirstShoutMessage.Replace("%PLAYER_NAME%", user));
+                                DiscordApi.SendMessage(Plugin.StaticConfig.PlayerFirstShoutMessage.Replace("%PLAYER_NAME%", user).Replace("%SHOUT%", text));
                             }
                             if (Plugin.StaticConfig.StatsShoutEnabled)
                             {


### PR DESCRIPTION
Addresses some wording inconsistencies. Closes #43 