### PR TITLE
Fix off by 1 error in TopPlayers.TopPlayersFormater()

### DIFF
--- a/src/Leaderboard/TopPlayers.cs
+++ b/src/Leaderboard/TopPlayers.cs
@@ -51,12 +51,12 @@ namespace DiscordConnector.Leaderboards
         private string TopPlayersFormater(Tuple<string, int>[] sortedTopPlayers)
         {
             string result = "";
-            for (int i = 1; i < Plugin.StaticConfig.IncludedNumberOfRankings; i++)
+            for (int i = 0; i < Plugin.StaticConfig.IncludedNumberOfRankings; i++)
             {
-                if (i - 1 < sortedTopPlayers.Length)
+                if (i < sortedTopPlayers.Length)
                 {
-                    Tuple<string, int> player = sortedTopPlayers[i - 1];
-                    result += $"{i}: {player.Item1}: {player.Item2}{Environment.NewLine}";
+                    Tuple<string, int> player = sortedTopPlayers[i];
+                    result += $"{i + 1}: {player.Item1}: {player.Item2}{Environment.NewLine}";
                 }
             }
             return result;


### PR DESCRIPTION
The top players leaderboard count is off by 1. For instance, if I set it to 5, it will only show 4. This is because the for loop is starting at 1 and using a `<` operator. I could have changed the operator to `<=`, but it seemed cleaner to just increment `i` when it was needed instead of decrementing it in multiple places.