### PR TITLE
return after sending the message for an event

### DIFF
--- a/src/EventWatcher.cs
+++ b/src/EventWatcher.cs
@@ -211,7 +211,7 @@ namespace DiscordConnector
             PreviousElapsed = Status.Elapsed;
         }
 
-        private void TriggerEventStart()
+        internal void TriggerEventStart()
         {
             if (Plugin.StaticConfig.EventStartMessageEnabled)
             {
@@ -224,6 +224,7 @@ namespace DiscordConnector
                 if (!Plugin.StaticConfig.EventStartPosEnabled)
                 {
                     DiscordApi.SendMessage(message);
+                    return;
                 }
                 if (Plugin.StaticConfig.DiscordEmbedsEnabled || !message.Contains("%POS%"))
                 {
@@ -242,7 +243,7 @@ namespace DiscordConnector
                 }
             }
         }
-        private void TriggerEventPaused()
+        internal void TriggerEventPaused()
         {
             if (Plugin.StaticConfig.EventPausedMessageEnabled)
             {
@@ -255,6 +256,7 @@ namespace DiscordConnector
                 if (!Plugin.StaticConfig.EventPausedPosEnabled)
                 {
                     DiscordApi.SendMessage(message);
+                    return;
                 }
                 if (Plugin.StaticConfig.DiscordEmbedsEnabled || !message.Contains("%POS%"))
                 {
@@ -273,7 +275,7 @@ namespace DiscordConnector
                 }
             }
         }
-        private void TriggerEventResumed()
+        internal void TriggerEventResumed()
         {
             if (Plugin.StaticConfig.EventResumedMessageEnabled)
             {
@@ -286,6 +288,7 @@ namespace DiscordConnector
                 if (!Plugin.StaticConfig.EventResumedPosEnabled)
                 {
                     DiscordApi.SendMessage(message);
+                    return;
                 }
                 if (Plugin.StaticConfig.DiscordEmbedsEnabled || !message.Contains("%POS%"))
                 {
@@ -304,7 +307,7 @@ namespace DiscordConnector
                 }
             }
         }
-        private void TriggerEventStop()
+        internal void TriggerEventStop()
         {
             if (Plugin.StaticConfig.EventStopMessageEnabled)
             {
@@ -317,6 +320,7 @@ namespace DiscordConnector
                 if (!Plugin.StaticConfig.EventStopPosEnabled)
                 {
                     DiscordApi.SendMessage(message);
+                    return;
                 }
                 if (Plugin.StaticConfig.DiscordEmbedsEnabled || !message.Contains("%POS%"))
                 {

--- a/src/Patches/EventPatches.cs
+++ b/src/Patches/EventPatches.cs
@@ -40,7 +40,6 @@ namespace DiscordConnector.Patches
 
                 if (__instance.m_time > 0)
                 {
-
                     if (Plugin.StaticConfig.EventResumedMessageEnabled)
                     {
                         string message = MessageTransformer.FormatEventMessage(
@@ -52,6 +51,7 @@ namespace DiscordConnector.Patches
                         if (!Plugin.StaticConfig.EventResumedPosEnabled)
                         {
                             DiscordApi.SendMessage(message);
+                            return;
                         }
                         if (Plugin.StaticConfig.DiscordEmbedsEnabled || !message.Contains("%POS%"))
                         {
@@ -83,6 +83,7 @@ namespace DiscordConnector.Patches
                         if (!Plugin.StaticConfig.EventStartPosEnabled)
                         {
                             DiscordApi.SendMessage(message);
+                            return;
                         }
                         if (Plugin.StaticConfig.DiscordEmbedsEnabled || !message.Contains("%POS%"))
                         {
@@ -144,6 +145,7 @@ namespace DiscordConnector.Patches
                         if (!Plugin.StaticConfig.EventPausedPosEnabled)
                         {
                             DiscordApi.SendMessage(message);
+                            return;
                         }
                         if (Plugin.StaticConfig.DiscordEmbedsEnabled || !message.Contains("%POS%"))
                         {
@@ -175,6 +177,7 @@ namespace DiscordConnector.Patches
                         if (!Plugin.StaticConfig.EventStopPosEnabled)
                         {
                             DiscordApi.SendMessage(message);
+                            return;
                         }
                         if (Plugin.StaticConfig.DiscordEmbedsEnabled || !message.Contains("%POS%"))
                         {


### PR DESCRIPTION
address #86 

If you had fancier discord messages enabled and position disabled this would send a message twice.