### PR TITLE
fix: 🐛 if message values are empty/null, send a valid string

### DIFF
--- a/src/PluginInfo.cs
+++ b/src/PluginInfo.cs
@@ -17,7 +17,7 @@ namespace DiscordConnector
     {
         public const string PLUGIN_ID = "games.nwest.valheim.discordconnector";
         public const string PLUGIN_NAME = "Valheim Discord Connector";
-        public const string PLUGIN_VERSION = "1.7.2";
+        public const string PLUGIN_VERSION = "1.7.1";
         public const string PLUGIN_REPO_SHORT = "github: nwesterhausen/valheim-discordconnector";
         public const string PLUGIN_AUTHOR = "Nicholas Westerhausen";
     }


### PR DESCRIPTION
Resolving #117 