### PR TITLE
chore: bump release 2.1.12

### DIFF
--- a/DiscordConnector.csproj
+++ b/DiscordConnector.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <!-- Set the path to the game folder. This is used when including references below -->
-    <GamePath Condition="$(GamePath) == ''">G:\Valheim\0.214.2</GamePath>
+    <GamePath Condition="$(GamePath) == ''">G:\Valheim\0.214.300</GamePath>
     <!-- Make the references to folders used in the build process a lot simpler -->
     <BinDir>$(ProjectDir)bin/</BinDir>
     <DiscordConnectorDir>$(BinDir)DiscordConnector/</DiscordConnectorDir>
@@ -39,7 +39,7 @@
     <Reference Include="0Harmony, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(GamePath)\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="BepInEx, Version=5.4.19.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="BepInEx, Version=5.4.21.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(GamePath)\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
     <!-- Valheim Assembly Dependencies -->

--- a/Metadata/README.md
+++ b/Metadata/README.md
@@ -34,6 +34,10 @@ See the [current roadmap](https://github.com/nwesterhausen/valheim-discordconnec
 
 ## Changelog
 
+## Version 2.1.12
+
+Update to Valheim 0.214.300
+
 ## Version 2.1.11
 
 This is for build 0.214.2 onward of Valheim. The signature of the chat messages was changed which was causing an argument out of bounds exception with Discord Connector.

--- a/Metadata/manifest.json
+++ b/Metadata/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "DiscordConnector",
-  "version_number": "2.1.11",
+  "version_number": "2.1.12",
   "website_url": "https://discordconnector.valheim.nwest.games/",
   "description": "Connects your Valheim server to a Discord webhook. Works for both dedicated and client-hosted servers.",
-  "dependencies": ["denikson-BepInExPack_Valheim-5.4.1901"]
+  "dependencies": ["denikson-BepInExPack_Valheim-5.4.2101"]
 }

--- a/Metadata/thunderstore.toml
+++ b/Metadata/thunderstore.toml
@@ -4,13 +4,13 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "nwesterhausen"
 name = "DiscordConnector"
-versionNumber = "2.1.11"
+versionNumber = "2.1.12"
 description = "Connects your Valheim server to a Discord webhook. Works for both dedicated and client-hosted servers."
 websiteUrl = "https://discordconnector.valheim.nwest.games/"
 containsNsfwContent = false
 
 [package.dependencies]
-denikson-BepInExPack_Valheim = "5.4.1901"
+denikson-BepInExPack_Valheim = "5.4.2101"
 
 [build]
 icon = "./icon.png"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build](https://github.com/nwesterhausen/valheim-discordconnector/actions/workflows/dotnet.yml/badge.svg)](https://github.com/nwesterhausen/valheim-discordconnector/actions/workflows/dotnet.yml)
 [![Publish](https://github.com/nwesterhausen/valheim-discordconnector/actions/workflows/publish.yml/badge.svg)](https://github.com/nwesterhausen/valheim-discordconnector/actions/workflows/publish.yml)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/nwesterhausen/valheim-discordconnector?label=Github%20Release&style=flat&labelColor=%2332393F)](https://github.com/nwesterhausen/valheim-discordconnector/releases/latest)
-[![Thunderstore.io](https://img.shields.io/badge/Thunderstore.io-2.1.11-%23375a7f?style=flat&labelColor=%2332393F)](https://valheim.thunderstore.io/package/nwesterhausen/DiscordConnector/)
+[![Thunderstore.io](https://img.shields.io/badge/Thunderstore.io-2.1.12-%23375a7f?style=flat&labelColor=%2332393F)](https://valheim.thunderstore.io/package/nwesterhausen/DiscordConnector/)
 [![NexusMods](https://img.shields.io/badge/NexusMods-2.1.11-%23D98F40?style=flat&labelColor=%2332393F)](https://www.nexusmods.com/valheim/mods/1551/)
 
 Connect your Valheim server to Discord. ([See website for installation or configuration instructions](https://discordconnector.valheim.nwest.games/)). This plugin is largely based on [valheim-discord-notifier](https://github.com/aequasi/valheim-discord-notifier), but this plugin supports randomized messages, muting players, and Discord message embeds.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 A full changelog of changes, dating all the way back to the first release.
 
+## Version 2.1.12
+
+Update to Valheim 0.214.300
+
 ## Version 2.1.11
 
 This is for build 0.214.2 onward of Valheim. The signature of the chat messages was changed which was causing an argument out of bounds exception with Discord Connector.

--- a/src/PluginInfo.cs
+++ b/src/PluginInfo.cs
@@ -16,7 +16,7 @@ internal static class PluginInfo
 {
     public const string PLUGIN_ID = "games.nwest.valheim.discordconnector";
     public const string PLUGIN_NAME = "Valheim Discord Connector";
-    public const string PLUGIN_VERSION = "2.1.11";
+    public const string PLUGIN_VERSION = "2.1.12";
     public const string PLUGIN_REPO_SHORT = "github: nwesterhausen/valheim-discordconnector";
     public const string PLUGIN_AUTHOR = "Nicholas Westerhausen";
     public const string SHORT_PLUGIN_ID = "discordconnector";


### PR DESCRIPTION
Handles update for Valheim 0.214.300 and updates the BepInEx dependency.