### PR TITLE
Implement time online leaderboard.

### DIFF
--- a/DiscordConnector.csproj
+++ b/DiscordConnector.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <!-- Set the path to the game folder. This is used when including references below -->
-    <GamePath Condition="$(GamePath) == ''">G:\Valheim\0.217.38</GamePath>
+    <GamePath Condition="$(GamePath) == ''">C:\Program Files (x86)\Steam\steamapps\common\Valheim</GamePath>
     <!-- Make the references to folders used in the build process a lot simpler -->
     <BinDir>$(ProjectDir)bin/</BinDir>
     <DiscordConnectorDir>$(BinDir)DiscordConnector/</DiscordConnectorDir>

--- a/src/Leaderboard/Composer.cs
+++ b/src/Leaderboard/Composer.cs
@@ -78,6 +78,17 @@ internal class Composer : Base
                 }
             }
         }
+        if (rankings.ContainsKey(Statistic.TimeOnline))
+        {
+            List<CountResult> timeOnlineRankings;
+            if (rankings.TryGetValue(Statistic.TimeOnline, out timeOnlineRankings))
+            {
+                if (timeOnlineRankings.Count > 0)
+                {
+                    leaderFields.Add(Tuple.Create("Time Online", LeaderBoard.RankedSecondsToString(timeOnlineRankings)));
+                }
+            }
+        }
 
         string discordContent = MessageTransformer.FormatLeaderBoardHeader(
             settings.DisplayedHeading, settings.NumberListings

--- a/src/Leaderboard/Leaderboard.cs
+++ b/src/Leaderboard/Leaderboard.cs
@@ -42,6 +42,38 @@ namespace DiscordConnector
             }
             return res;
         }
+
+        // https://stackoverflow.com/a/4423615/624900
+        private static string ToReadableString(TimeSpan span)
+        {
+            string formatted = string.Format("{0}{1}{2}{3}",
+                span.Duration().Days > 0 ? string.Format("{0:0} day{1}, ", span.Days, span.Days == 1 ? string.Empty : "s") : string.Empty,
+                span.Duration().Hours > 0 ? string.Format("{0:0} hour{1}, ", span.Hours, span.Hours == 1 ? string.Empty : "s") : string.Empty,
+                span.Duration().Minutes > 0 ? string.Format("{0:0} minute{1}, ", span.Minutes, span.Minutes == 1 ? string.Empty : "s") : string.Empty,
+                span.Duration().Seconds > 0 ? string.Format("{0:0} second{1}", span.Seconds, span.Seconds == 1 ? string.Empty : "s") : string.Empty);
+
+            if (formatted.EndsWith(", ")) formatted = formatted.Substring(0, formatted.Length - 2);
+
+            if (string.IsNullOrEmpty(formatted)) formatted = "0 seconds";
+
+            return formatted;
+        }
+
+        /// <summary>
+        /// Same as RankedCountResultToString but formats as a time duration, assuming integer seconds.
+        /// </summary>
+        /// <param name="rankings">A pre-sorted list of CountResults.</param>
+        /// <returns>String ready to send to discord listing each player and their duration.</returns>
+        public static string RankedSecondsToString(List<Records.CountResult> rankings)
+        {
+            string res = "";
+            for (int i = 0; i < rankings.Count; i++)
+            {
+                string formattedDuration = ToReadableString(TimeSpan.FromSeconds(rankings[i].Count));
+                res += $"{i + 1}: {rankings[i].Name}: {formattedDuration}{Environment.NewLine}";
+            }
+            return res;
+        }
     }
 }
 

--- a/src/Records/Classes/PlayerNames.cs
+++ b/src/Records/Classes/PlayerNames.cs
@@ -10,11 +10,17 @@ public class PlayerToName
     public System.DateTime InsertedDate { get; }
 
     public PlayerToName(string characterName, string playerHostName)
+        : this(ObjectId.NewObjectId(), characterName, playerHostName, System.DateTime.Now)
     {
-        _id = ObjectId.NewObjectId();
+    }
+
+    [BsonCtor]
+    public PlayerToName(ObjectId id, string characterName, string playerId, System.DateTime insertedDate)
+    {
+        _id = id;
         CharacterName = characterName;
-        PlayerId = playerHostName;
-        InsertedDate = System.DateTime.Now;
+        PlayerId = playerId;
+        InsertedDate = insertedDate;
     }
 
     public override string ToString()

--- a/src/Records/Classes/SimpleStat.cs
+++ b/src/Records/Classes/SimpleStat.cs
@@ -10,31 +10,23 @@ public class SimpleStat
     public string PlayerId { get; }
     public Position Pos { get; }
 
-    public SimpleStat(string name, string playerHostName)
+    public SimpleStat(string name, string playerId, float x, float y, float z)
+        : this(ObjectId.NewObjectId(), name, System.DateTime.Now, playerId, new Position(x, y, z))
     {
-        StatId = ObjectId.NewObjectId();
-        Name = name;
-        PlayerId = playerHostName;
-        Date = System.DateTime.Now;
-        Pos = new Position();
-    }
-
-    public SimpleStat(string name, string playerHostName, float x, float y, float z)
-    {
-        StatId = ObjectId.NewObjectId();
-        Name = name;
-        PlayerId = playerHostName;
-        Date = System.DateTime.Now;
-        Pos = new Position(x, y, z);
     }
 
     [BsonCtor]
-    public SimpleStat(ObjectId _id, string name, System.DateTime date, string playerHostName, Position pos)
+    public SimpleStat(ObjectId id, ObjectId statId, string name, System.DateTime date, string playerId, BsonDocument pos)
+        : this(statId, name, date, playerId, BsonMapper.Global.Deserialize<Position>(pos))
     {
-        StatId = _id;
+    }
+
+    public SimpleStat(ObjectId statId, string name, System.DateTime date, string playerId, Position pos)
+    {
+        StatId = statId;
         Name = name;
         Date = date;
-        PlayerId = playerHostName;
+        PlayerId = playerId;
         Pos = pos;
     }
 

--- a/src/Records/Database.cs
+++ b/src/Records/Database.cs
@@ -357,7 +357,7 @@ internal class Database
             }
             if (endDate != null)
             {
-                joinsQuery = joinsQuery.Where(x => startCompare(x.Date.CompareTo(endDate.GetValueOrDefault())));
+                joinsQuery = joinsQuery.Where(x => endCompare(x.Date.CompareTo(endDate.GetValueOrDefault())));
             }
 
             // Grab joins and leaves for player and sort them by time.

--- a/src/Records/Database.cs
+++ b/src/Records/Database.cs
@@ -1,6 +1,8 @@
 ﻿
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using DiscordConnector.LeaderBoards;
 using LiteDB;
@@ -306,65 +308,21 @@ internal class Database
             case Categories.Shout:
                 return CountAllRecordsGrouped(ShoutCollection);
             case Categories.TimeOnline:
-                return AllTimeOnlineRecordsGrouped();
+                return TimeOnlineRecordsGrouped();
             default:
                 Plugin.StaticLogger.LogDebug($"CountAllRecordsGrouped, invalid key '{key}'");
                 return new List<CountResult>();
         }
     }
 
-    private List<CountResult> AllTimeOnlineRecordsGrouped()
+    private struct JoinLeaveTime
     {
-
-        PlayerToName[] players = PlayerToNameCollection.Query().ToArray();
-        List<CountResult> results = new List<CountResult>();
-
-        foreach (PlayerToName player in players)
-        {
-            // Create a spot to record total online time for player
-            Tuple<string, string> playerTuple = Tuple.Create(player.PlayerId, player.CharacterName);
-            System.TimeSpan onlineTime = System.TimeSpan.FromSeconds(0.0);
-
-            // Grab joins and leaves for player
-            SimpleStat[] joins = JoinCollection.Query().Where(x => x.PlayerId == player.PlayerId && x.Name == player.CharacterName).ToArray();
-            SimpleStat[] leaves = LeaveCollection.Query().Where(x => x.PlayerId == player.PlayerId && x.Name == player.CharacterName).ToArray();
-
-            // Compare their lengths
-            Plugin.StaticLogger.LogDebug($"{player.PlayerId} as {player.CharacterName} has {joins.Length} joins, {leaves.Length}");
-            int sessionDifference = joins.Length - leaves.Length;
-            if (sessionDifference > 1)
-            {
-                Plugin.StaticLogger.LogDebug($"{sessionDifference} more joins than leaves, timeOnline likely to be very inaccurate");
-            }
-            // Should either be equal to joins.Length or joins.Length - 1 (basically leaves.Length)
-            int travelableLength = joins.Length - sessionDifference;
-
-            // Add up time between each one.
-            for (int i = 0; i < travelableLength; i++)
-            {
-                // Get the dates
-                System.DateTime login = joins[i].Date;
-                System.DateTime logout = leaves[i].Date;
-
-                // Get the time between them
-                System.TimeSpan difference = logout.Subtract(login);
-
-                // Add that time to the player's total
-                onlineTime.Add(difference);
-            }
-
-            // Total time is then stored
-            Plugin.StaticLogger.LogDebug($"{onlineTime.ToString()} total online time.");
-
-            // Append to list
-            results.Add(new CountResult(player.CharacterName, (int)onlineTime.TotalSeconds));
-        }
-
-        return results;
+        public System.DateTime Time;
+        public bool IsJoin;
     }
 
     /// <summary>
-    /// Provides time online in seconds for all players within the date range provided. By default, it includes the start date.
+    /// Provides time online in seconds for all players within the date range provided. By default, it includes all time.
     /// 
     /// This looks through the provided simple stat table and counts up time differences between joins and leaves.
     /// </summary>
@@ -373,152 +331,74 @@ internal class Database
     /// <param name="inclusiveStart">Whether to include the start date or not in the returned results. If true, it will use `>=` for the startDate comparison; otherwise `>`.</param>
     /// <param name="inclusiveEnd">Whether to include the end date or not in the returned results. If true, it will use `<=` for the startDate comparison; otherwise `<`.</param>
     /// <returns>List of counts with CharacterName and Total (x) for the provided SimpleStat collection.</returns>
-    private List<CountResult> TimeOnlineRecordsWhereDate(System.DateTime startDate, System.DateTime endDate, bool inclusiveStart = true, bool inclusiveEnd = true)
+    private List<CountResult> TimeOnlineRecordsGrouped(System.DateTime? startDate = null, System.DateTime? endDate = null, bool inclusiveStart = true, bool inclusiveEnd = true)
     {
 
         PlayerToName[] players = PlayerToNameCollection.Query().ToArray();
-        List<CountResult> results = new List<CountResult>();
+        List<CountResult> results = new();
 
         foreach (PlayerToName player in players)
         {
-            // Create a spot to record total online time for player
-            Tuple<string, string> playerTuple = Tuple.Create(player.PlayerId, player.CharacterName);
+            // Create a spot to record total online time for player.
             System.TimeSpan onlineTime = System.TimeSpan.FromSeconds(0.0);
 
-            // Grab joins and leaves for player
-            SimpleStat[] joins;
-            SimpleStat[] leaves;
+            var joinsQuery = JoinCollection.Query().Where(x => x.PlayerId.Equals(player.PlayerId) && x.Name.Equals(player.CharacterName));
+            var leavesQuery = LeaveCollection.Query().Where(x => x.PlayerId.Equals(player.PlayerId) && x.Name.Equals(player.CharacterName));
 
-
-            if (inclusiveStart && inclusiveEnd)
+            Func<int, bool> startCompare = inclusiveStart ?
+                (x) => x >= 0 :
+                (x) => x > 0;
+            Func<int, bool> endCompare = inclusiveEnd ?
+                (x) => x <= 0 :
+                (x) => x < 0;
+            if (startDate != null)
             {
-                joins = JoinCollection.Query()
-                        // Filter to dates inclusively
-                        .Where(x => x.Date.Year >= startDate.Date.Year
-                            && x.Date.Month >= startDate.Date.Month
-                            && x.Date.Day >= startDate.Date.Day
-                            && x.Date.Year <= endDate.Date.Year
-                            && x.Date.Month <= endDate.Date.Month
-                            && x.Date.Day <= endDate.Date.Day)
-                        // Filter to player
-                        .Where(x => x.PlayerId == player.PlayerId && x.Name == player.CharacterName)
-                        .ToArray();
-                leaves = LeaveCollection.Query()
-                        // Filter to dates inclusively
-                        .Where(x => x.Date.Year >= startDate.Date.Year
-                            && x.Date.Month >= startDate.Date.Month
-                            && x.Date.Day >= startDate.Date.Day
-                            && x.Date.Year <= endDate.Date.Year
-                            && x.Date.Month <= endDate.Date.Month
-                            && x.Date.Day <= endDate.Date.Day)
-                        // Filter to player
-                        .Where(x => x.PlayerId == player.PlayerId && x.Name == player.CharacterName)
-                        .ToArray();
-
+                joinsQuery = joinsQuery.Where(x => startCompare(x.Date.CompareTo(startDate.GetValueOrDefault())));
             }
-            else if (inclusiveEnd)
+            if (endDate != null)
             {
-                joins = JoinCollection.Query()
-                        // Filter to dates: end date inclusively, start date exclusively
-                        .Where(x => x.Date.Year > startDate.Date.Year
-                            && x.Date.Month > startDate.Date.Month
-                            && x.Date.Day > startDate.Date.Day
-                            && x.Date.Year <= endDate.Date.Year
-                            && x.Date.Month <= endDate.Date.Month
-                            && x.Date.Day <= endDate.Date.Day)
-                        // Filter to player
-                        .Where(x => x.PlayerId == player.PlayerId && x.Name == player.CharacterName)
-                        .ToArray();
-                leaves = LeaveCollection.Query()
-                        // Filter to dates: end date inclusively, start date exclusively
-                        .Where(x => x.Date.Year > startDate.Date.Year
-                            && x.Date.Month > startDate.Date.Month
-                            && x.Date.Day > startDate.Date.Day
-                            && x.Date.Year <= endDate.Date.Year
-                            && x.Date.Month <= endDate.Date.Month
-                            && x.Date.Day <= endDate.Date.Day)
-                        // Filter to player
-                        .Where(x => x.PlayerId == player.PlayerId && x.Name == player.CharacterName)
-                        .ToArray();
-            }
-            else if (inclusiveStart)
-            {
-                joins = JoinCollection.Query()
-                        // Filter to dates: start date inclusively, end date exclusively
-                        .Where(x => x.Date.Year >= startDate.Date.Year
-                            && x.Date.Month >= startDate.Date.Month
-                            && x.Date.Day >= startDate.Date.Day
-                            && x.Date.Year < endDate.Date.Year
-                            && x.Date.Month < endDate.Date.Month
-                            && x.Date.Day < endDate.Date.Day)
-                        // Filter to player
-                        .Where(x => x.PlayerId == player.PlayerId && x.Name == player.CharacterName)
-                        .ToArray();
-                leaves = LeaveCollection.Query()
-                        // Filter to dates: start date inclusively, end date exclusively
-                        .Where(x => x.Date.Year >= startDate.Date.Year
-                            && x.Date.Month >= startDate.Date.Month
-                            && x.Date.Day >= startDate.Date.Day
-                            && x.Date.Year < endDate.Date.Year
-                            && x.Date.Month < endDate.Date.Month
-                            && x.Date.Day < endDate.Date.Day)
-                        // Filter to player
-                        .Where(x => x.PlayerId == player.PlayerId && x.Name == player.CharacterName)
-                        .ToArray();
-            }
-            else
-            {
-                joins = JoinCollection.Query()
-                        // Filter to dates exclusively
-                        .Where(x => x.Date.Year > startDate.Date.Year
-                            && x.Date.Month > startDate.Date.Month
-                            && x.Date.Day > startDate.Date.Day
-                            && x.Date.Year < endDate.Date.Year
-                            && x.Date.Month < endDate.Date.Month
-                            && x.Date.Day < endDate.Date.Day)
-                        // Filter to player
-                        .Where(x => x.PlayerId == player.PlayerId && x.Name == player.CharacterName)
-                        .ToArray();
-                leaves = LeaveCollection.Query()
-                        // Filter to dates exclusively
-                        .Where(x => x.Date.Year > startDate.Date.Year
-                            && x.Date.Month > startDate.Date.Month
-                            && x.Date.Day > startDate.Date.Day
-                            && x.Date.Year < endDate.Date.Year
-                            && x.Date.Month < endDate.Date.Month
-                            && x.Date.Day < endDate.Date.Day)
-                        // Filter to player
-                        .Where(x => x.PlayerId == player.PlayerId && x.Name == player.CharacterName)
-                        .ToArray();
+                joinsQuery = joinsQuery.Where(x => startCompare(x.Date.CompareTo(endDate.GetValueOrDefault())));
             }
 
+            // Grab joins and leaves for player and sort them by time.
+            JoinLeaveTime[] joins = Array.ConvertAll(joinsQuery.ToArray(),
+                stat => new JoinLeaveTime { Time = stat.Date, IsJoin = true });
+            JoinLeaveTime[] leaves = Array.ConvertAll(leavesQuery.ToArray(),
+                stat => new JoinLeaveTime { Time = stat.Date, IsJoin = false });
+            JoinLeaveTime[] sortedJoinLeaves = joins.Concat(leaves).OrderBy(j => j.Time).ToArray();
 
-            // Compare their lengths
-            Plugin.StaticLogger.LogDebug($"{player.PlayerId} as {player.CharacterName} has {joins.Length} joins, {leaves.Length}");
-            int sessionDifference = joins.Length - leaves.Length;
-            if (sessionDifference > 1)
-            {
-                Plugin.StaticLogger.LogDebug($"{sessionDifference} more joins than leaves, timeOnline likely to be very inaccurate");
-            }
-            // Should either be equal to joins.Length or joins.Length - 1 (basically leaves.Length)
-            int travelableLength = joins.Length - sessionDifference;
+            Plugin.StaticLogger.LogDebug($"{player.PlayerId} as {player.CharacterName} has {joins.Length} joins, {leaves.Length} leaves");
 
-            // Add up time between each one.
-            for (int i = 0; i < travelableLength; i++)
-            {
-                // Get the dates
-                System.DateTime login = joins[i].Date;
-                System.DateTime logout = leaves[i].Date;
-
-                // Get the time between them
-                System.TimeSpan difference = logout.Subtract(login);
-
-                // Add that time to the player's total
-                onlineTime.Add(difference);
+            System.DateTime? joinedTime = null;
+            foreach (JoinLeaveTime joinLeaveTime in sortedJoinLeaves) {
+                if (joinedTime == null)
+                {
+                    // Player is not currently joined, so expecting a join.
+                    if (joinLeaveTime.IsJoin)
+                    {
+                        joinedTime = joinLeaveTime.Time;
+                    } else
+                    {
+                        Plugin.StaticLogger.LogDebug($"Player {player.CharacterName} left at {joinLeaveTime.Time} but was not joined.");
+                    }
+                } else
+                {
+                    // Player is currently joined, expecting a leave.
+                    if (joinLeaveTime.IsJoin)
+                    {
+                        Plugin.StaticLogger.LogDebug($"Player {player.CharacterName} joined at {joinLeaveTime.Time} but was already joined at {joinedTime}");
+                        joinedTime = joinLeaveTime.Time;
+                    }
+                    else
+                    {
+                        onlineTime += joinLeaveTime.Time.Subtract(joinedTime ?? joinLeaveTime.Time);
+                        joinedTime = null;
+                    }
+                }
             }
 
             // Total time is then stored
-            Plugin.StaticLogger.LogDebug($"{onlineTime.ToString()} total online time.");
+            Plugin.StaticLogger.LogDebug($"{onlineTime} total online time.");
 
             // Append to list
             results.Add(new CountResult(player.CharacterName, (int)onlineTime.TotalSeconds));
@@ -589,7 +469,7 @@ internal class Database
             case Categories.Shout:
                 return CountAllRecordsGroupsWhereDate(ShoutCollection, startDate, endDate, inclusiveStart, inclusiveEnd);
             case Categories.TimeOnline:
-                return TimeOnlineRecordsWhereDate(startDate, endDate, inclusiveStart, inclusiveEnd);
+                return TimeOnlineRecordsGrouped(startDate, endDate, inclusiveStart, inclusiveEnd);
             default:
                 Plugin.StaticLogger.LogDebug($"CountTodaysRecordsGrouped, invalid key '{key}'");
                 return new List<CountResult>();


### PR DESCRIPTION
- Implement the time online leaderboard which was not enabled.
- Fix `BsonCtor` annotated types: `PlayerToName` and `SimpleStat` were not loading columns correctly from the database, but nothing was using the additional columns until now.
- Consolidate `AllTimeOnlineRecordsGrouped` and `TimeOnlineRecordsWhereDate` methods into a single new parameterized method, `TimeOnlineRecordsGrouped`, to remove duplicated code.
- Reimplement the time online calculation algorithm, sorting all joins and leaves by date and summing adjacent join and leave events.
- Fixes #260