### PR TITLE
Add ability to report the current day number.

### DIFF
--- a/docs/config/messages.server.md
+++ b/docs/config/messages.server.md
@@ -35,3 +35,9 @@ Set the message that will be sent when the server finishes shutting down. If you
 Type: `String`, default value: `The world has been saved.`
 
 Set the message that will be sent when the server saves the world data. If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';' If you use %PUBLICIP% in this message, it will be replaced with the public IP address of the server.
+
+## Server New Day Message
+
+Type: `String`, default value: `Day Number %DAY_NUMBER%`
+
+Set the message that will be sent when a new day starts. The `%DAY_NUMBER%` variable gets replaced with the new day number (e.g. "Day Number 34").

--- a/docs/config/webhook.events.md
+++ b/docs/config/webhook.events.md
@@ -26,6 +26,7 @@ Take note that some of these events are subsets of the [special cases](/config/w
 | serverStop       | Server beings stopping                        | Yes                |
 | serverShutdown   | Server has stopped                            | Yes                |
 | serverSave       | The world has been saved                      | Yes                |
+| serverNewDay     | A new day begins on the server                | Yes                |
 | eventStart       | An event starts                               | Yes                |
 | eventPaused      | An event pauses                               | Yes                |
 | eventResumed     | An event resumes                              | Yes                |

--- a/src/Config/MessagesConfig.cs
+++ b/src/Config/MessagesConfig.cs
@@ -22,6 +22,7 @@ internal class MessagesConfig
     private ConfigEntry<string> serverStopMessage;
     private ConfigEntry<string> serverShutdownMessage;
     private ConfigEntry<string> serverSavedMessage;
+    private ConfigEntry<string> serverNewDayMessage;
 
     // Player Messages
     private ConfigEntry<string> playerJoinMessage;
@@ -95,6 +96,11 @@ internal class MessagesConfig
             "Set the message that will be sent when the server saves the world data." + Environment.NewLine +
             "If you want to have this choose from a variety of messages at random, separate each message with a semicolon ';'" + Environment.NewLine +
             "If you use %PUBLICIP% in this message, it will be replaced with the public IP address of the server.");
+        serverNewDayMessage = config.Bind<string>(SERVER_MESSAGES,
+            "Server New Day Message",
+            "Day Number %DAY_NUMBER%",
+            "Set the message that will be sent when a new day starts." + Environment.NewLine +
+            "The %DAY_NUMBER% variable gets replaced with the day number.");
 
         // Messages.Player
         playerJoinMessage = config.Bind<string>(PLAYER_MESSAGES,
@@ -216,6 +222,7 @@ internal class MessagesConfig
         jsonString += $"\"stopMessage\":\"{serverStopMessage.Value}\",";
         jsonString += $"\"shutdownMessage\":\"{serverShutdownMessage.Value}\",";
         jsonString += $"\"savedMessage\":\"{serverSavedMessage.Value}\"";
+        jsonString += $"\"serverNewDayMessage\":\"{serverNewDayMessage.Value}\"";
         jsonString += "},";
 
         jsonString += $"\"{PLAYER_MESSAGES}\":{{";
@@ -274,6 +281,7 @@ internal class MessagesConfig
     public string StopMessage => GetRandomStringFromValue(serverStopMessage);
     public string ShutdownMessage => GetRandomStringFromValue(serverShutdownMessage);
     public string SaveMessage => GetRandomStringFromValue(serverSavedMessage);
+    public string NewDayMessage => GetRandomStringFromValue(serverNewDayMessage);
 
     // Messages.Player
     public string JoinMessage => GetRandomStringFromValue(playerJoinMessage);

--- a/src/Config/PluginConfig.cs
+++ b/src/Config/PluginConfig.cs
@@ -161,6 +161,7 @@ internal class PluginConfig
     public bool EventPausedMessageEnabled => togglesConfig.EventPausedMessageEnabled;
     public bool EventResumedMessageEnabled => togglesConfig.EventResumedMessageEnabled;
     public bool ChatShoutAllCaps => togglesConfig.ChatShoutAllCaps;
+    public bool NewDayNumberEnabled => togglesConfig.NewDayNumberEnabled;
 
     // Toggles.Stats
     public bool StatsDeathEnabled => mainConfig.CollectStatsEnabled && togglesConfig.StatsDeathEnabled;
@@ -199,6 +200,7 @@ internal class PluginConfig
     public string StopMessage => messagesConfig.StopMessage;
     public string ShutdownMessage => messagesConfig.ShutdownMessage;
     public string SaveMessage => messagesConfig.SaveMessage;
+    public string NewDayMessage => messagesConfig.NewDayMessage;
 
     // Messages.Players
     public string JoinMessage => messagesConfig.JoinMessage;

--- a/src/Config/TogglesConfig.cs
+++ b/src/Config/TogglesConfig.cs
@@ -30,6 +30,7 @@ internal class TogglesConfig
     private ConfigEntry<bool> eventStopMessageToggle;
     private ConfigEntry<bool> eventResumedMessageToggle;
     private ConfigEntry<bool> chatShoutAllCaps;
+    private ConfigEntry<bool> newDayNumberToggle;
 
     // Position Coordinates Toggles
     private ConfigEntry<bool> playerLeavePosToggle;
@@ -139,6 +140,10 @@ internal class TogglesConfig
             "Send All Caps Shout Messages",
             false,
             "If enabled, this will send all shout messages to Discord in all caps.");
+        newDayNumberToggle = config.Bind<bool>(MESSAGES_TOGGLES,
+            "Send Message For New Day Number",
+            true,
+            "If enabled, this will send a message with the current day number on new days.");
 
         // Position Toggles
         playerJoinPosToggle = config.Bind<bool>(POSITION_TOGGLES,
@@ -265,6 +270,7 @@ internal class TogglesConfig
         jsonString += $"\"eventStoppedEnabled\":\"{EventPausedMessageEnabled}\",";
         jsonString += $"\"eventResumedEnabled\":\"{EventResumedMessageEnabled}\",";
         jsonString += $"\"chatShoutAllCaps\":\"{ChatShoutAllCaps}\"";
+        jsonString += $"\"newDayNumberToggle\":\"{NewDayNumberEnabled}\"";
         jsonString += "},";
 
         jsonString += $"\"{POSITION_TOGGLES}\":{{";
@@ -346,4 +352,5 @@ internal class TogglesConfig
     public bool DebugHttpRequestResponse => debugHttpRequestResponses.Value;
     public bool DebugDatabaseMethods => debugDatabaseMethods.Value;
     public bool ChatShoutAllCaps => chatShoutAllCaps.Value;
+    public bool NewDayNumberEnabled => newDayNumberToggle.Value;
 }

--- a/src/MessageTransformer.cs
+++ b/src/MessageTransformer.cs
@@ -25,6 +25,7 @@ internal static class MessageTransformer
     private const string EVENT_PLAYERS = "%PLAYERS%";
     private const string N = "%N%";
     private const string WORLD_NAME = "%WORLD_NAME%";
+    private const string DAY_NUMBER = "%DAY_NUMBER%";
 
     private static Regex OpenCaretRegex = new Regex(@"<[\w=]+>");
     private static Regex CloseCaretRegex = new Regex(@"</[\w]+>");
@@ -42,7 +43,8 @@ internal static class MessageTransformer
             .Replace(VAR_7, Plugin.StaticConfig.UserVariable7)
             .Replace(VAR_8, Plugin.StaticConfig.UserVariable8)
             .Replace(VAR_9, Plugin.StaticConfig.UserVariable9)
-            .Replace(PUBLIC_IP, Plugin.PublicIpAddress);
+            .Replace(PUBLIC_IP, Plugin.PublicIpAddress)
+            .Replace(DAY_NUMBER, EnvMan.instance != null ? EnvMan.instance.GetCurrentDay().ToString() : DAY_NUMBER);
     }
     private static string ReplaceDynamicVariables(string rawMessage)
     {

--- a/src/Patches/EnvManPatches.cs
+++ b/src/Patches/EnvManPatches.cs
@@ -1,0 +1,24 @@
+﻿using HarmonyLib;
+
+namespace DiscordConnector.Patches;
+internal class EnvManPatches
+{
+    [HarmonyPatch(typeof(EnvMan), nameof(EnvMan.UpdateTriggers))]
+    internal class OnNewDay
+    {
+        private static void Postfix(float oldDayFraction, float newDayFraction)
+        {
+            if (EnvMan.instance == null) return;
+
+            if (!Plugin.StaticConfig.NewDayNumberEnabled) return;
+
+            if (oldDayFraction > 0.2f && oldDayFraction < 0.25f && newDayFraction > 0.25f && newDayFraction < 0.3f)
+            {
+                DiscordApi.SendMessage(
+                    Webhook.Event.NewDayNumber,
+                    MessageTransformer.FormatServerMessage(Plugin.StaticConfig.NewDayMessage)
+                );
+            }
+        }
+    }
+}

--- a/src/Webhook.cs
+++ b/src/Webhook.cs
@@ -40,6 +40,7 @@ public class Webhook
         None,
         Other,
         CronJob,
+        NewDayNumber,
     }
 
     public static Event StringToEvent(string eventToken)
@@ -116,6 +117,9 @@ public class Webhook
 
             case "cronjob":
                 return Event.CronJob;
+
+            case "newDayNumber":
+                return Event.NewDayNumber;
 
             default:
                 Plugin.StaticLogger.LogDebug($"Unmatched event token '{eventToken}'");
@@ -244,7 +248,8 @@ class WebhookEntry
                 ev == Webhook.Event.ServerLaunch ||
                 ev == Webhook.Event.ServerShutdown ||
                 ev == Webhook.Event.ServerStart ||
-                ev == Webhook.Event.ServerStop)
+                ev == Webhook.Event.ServerStop ||
+                ev == Webhook.Event.NewDayNumber)
             {
                 return true;
             }


### PR DESCRIPTION
This prints the world day number on server start and on each new day, e.g.

```
Server is starting up.
Server has started!
Day Number 30
Dev has joined.
The world has been saved.
Day Number 31
```