### PR TITLE
Client bug fixes

### DIFF
--- a/DiscordConnector.Client/Metadata/manifest.json
+++ b/DiscordConnector.Client/Metadata/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "DiscordConnector_Client",
-  "version_number": "1.0.0",
+  "version_number": "1.0.1",
   "website_url": "https://discord-connector.valheim.games.nwest.one/",
   "description": "Connects your Valheim server to a Discord webhook. This must be installed on the client.",
   "dependencies": [

--- a/DiscordConnector.Client/Metadata/thunderstore.toml
+++ b/DiscordConnector.Client/Metadata/thunderstore.toml
@@ -4,7 +4,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "nwesterhausen"
 name = "DiscordConnector_Client"
-versionNumber = "1.0.0"
+versionNumber = "1.0.1"
 description = "Connects your Valheim server to a Discord webhook. This must be installed on the client."
 websiteUrl = "https://discord-connector.valheim.games.nwest.one/"
 containsNsfwContent = false

--- a/DiscordConnector.Client/Patches/ChatPatches.cs
+++ b/DiscordConnector.Client/Patches/ChatPatches.cs
@@ -33,6 +33,12 @@ internal class ChatPatches
         private static void Prefix(ref GameObject go, ref long senderID, ref Vector3 pos, ref Talker.Type type,
             ref UserInfo sender, ref string text)
         {
+            if (senderID != ZNet.GetUID())
+            {
+                DiscordConnectorClientPlugin.StaticLogger.LogDebug($"Ignoring message from other {senderID} != {ZNet.GetUID()}");
+                return;
+            }
+            
             DiscordConnectorClientPlugin.StaticLogger.LogDebug(
                 $"User details: name:{sender.Name}  DisplayName():{sender.GetDisplayName()} senderID:{senderID}  type:{type}  text:{text}");
 

--- a/DiscordConnector.Client/Plugin.cs
+++ b/DiscordConnector.Client/Plugin.cs
@@ -12,7 +12,7 @@ namespace DiscordConnector;
 public class DiscordConnectorClientPlugin : BaseUnityPlugin
 {
     internal const string ModName = "DiscordConnectorClient";
-    internal const string ModVersion = "1.0.0";
+    internal const string ModVersion = "1.0.1";
     internal const string Author = "nwesterhausen";
     private const string ModGuid = Author + "." + ModName;
     private const string LegacyConfigPath = "games.nwest.valheim.discordconnector";

--- a/DiscordConnector.Client/Plugin.cs
+++ b/DiscordConnector.Client/Plugin.cs
@@ -23,7 +23,7 @@ public class DiscordConnectorClientPlugin : BaseUnityPlugin
 
     public DiscordConnectorClientPlugin()
     {
-        StaticLogger = new VdcLogger(Logger, Path.Combine(Paths.ConfigPath, LegacyConfigPath));
+        StaticLogger = new VdcLogger(Logger, Paths.ConfigPath);
     }
 
     private void Awake()

--- a/docs/changelog-Client.md
+++ b/docs/changelog-Client.md
@@ -2,6 +2,13 @@
 
 Here will be the record of changes for the client plugin.
 
+## Version 1.0.1
+
+### Fixes
+
+- Issue where clients were sending all messages "heard" on the client to the server, resulting in duplication of messages
+- Issue where the log file was not being created in the correct location (and causing the plugin to fail on clients)
+
 ## Version 1.0.0
 
 Initial release of the client plugin.


### PR DESCRIPTION

### Fixes

- Issue where clients were sending all messages "heard" on the client to the server, resulting in duplication of messages
- Issue where the log file was not being created in the correct location (and causing the plugin to fail on clients)