### PR TITLE
Fixing URI prefix issue

### DIFF
--- a/DiscordConnector/DiscordApi.cs
+++ b/DiscordConnector/DiscordApi.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Text;
-using System.Threading.Tasks;
 
 using Newtonsoft.Json;
 
@@ -485,19 +484,16 @@ internal class DiscordApi
             return;
         }
 
-        // Responsible for sending a JSON string to the webhook.
-        byte[] byteArray = Encoding.UTF8.GetBytes(serializedJson);
-
         if (DiscordConnectorPlugin.StaticConfig.PrimaryWebhook.HasEvent(ev))
         {
             DiscordConnectorPlugin.StaticLogger.LogDebug($"Sending {ev} message to Primary Webhook");
-            DispatchRequest(DiscordConnectorPlugin.StaticConfig.PrimaryWebhook, byteArray);
+            DispatchRequest(DiscordConnectorPlugin.StaticConfig.PrimaryWebhook, serializedJson);
         }
 
         if (DiscordConnectorPlugin.StaticConfig.SecondaryWebhook.HasEvent(ev))
         {
             DiscordConnectorPlugin.StaticLogger.LogDebug($"Sending {ev} message to Secondary Webhook");
-            DispatchRequest(DiscordConnectorPlugin.StaticConfig.SecondaryWebhook, byteArray);
+            DispatchRequest(DiscordConnectorPlugin.StaticConfig.SecondaryWebhook, serializedJson);
         }
 
         // Check for any extra webhooks that should be sent to
@@ -506,7 +502,7 @@ internal class DiscordApi
             if (webhook.HasEvent(ev))
             {
                 DiscordConnectorPlugin.StaticLogger.LogDebug($"Sending {ev} message to Extra Webhook: {webhook.Url}");
-                DispatchRequest(webhook, byteArray);
+                DispatchRequest(webhook, serializedJson);
             }
         }
     }
@@ -529,7 +525,7 @@ internal class DiscordApi
         // Responsible for sending a JSON string to the webhook.
         byte[] byteArray = Encoding.UTF8.GetBytes(serializedJson);
 
-        DispatchRequest(webhook, byteArray);
+        DispatchRequest(webhook, serializedJson);
     }
 
     /// <summary>
@@ -537,7 +533,7 @@ internal class DiscordApi
     /// </summary>
     /// <param name="webhook">The webhook to use for the request</param>
     /// <param name="byteArray">The payload as a byte array</param>
-    private static void DispatchRequest(WebhookEntry webhook, byte[] byteArray)
+    private static async void DispatchRequest(WebhookEntry webhook, string serializedJson)
     {
         if (string.IsNullOrEmpty(webhook.Url))
         {
@@ -548,100 +544,39 @@ internal class DiscordApi
         // Create an identifier for the request
         string requestId = GuidHelper.GenerateShortHexGuid();
         DiscordConnectorPlugin.StaticLogger.LogDebug(
-            $"DispatchRequest.{requestId}: sending {byteArray.Length} bytes to Discord");
+            $"DispatchRequest.{requestId}: sending {serializedJson} to Discord");
 
         // Create a web request to send the payload to discord
-        WebRequest request = WebRequest.Create(webhook.Url);
-        request.Method = "POST";
-        request.ContentType = "application/json";
-        request.ContentLength = byteArray.Length;
+        HttpClient request = new();
+        StringContent content = new(serializedJson, Encoding.UTF8, "application/json");
 
-        // Dispatch the request to discord and the response processing to an async task
-        Task.Run(() =>
+        try
         {
-            try
+            HttpResponseMessage response = await request.PostAsync(webhook.Url, content);
+            DiscordConnectorPlugin.StaticLogger.LogDebug(
+                                $"DispatchRequest.{requestId}: Response Code: {response.StatusCode}");
+
+            if(response.StatusCode != HttpStatusCode.NoContent)
             {
-                // We have to write the data to the request
-                using (Stream dataStream = request.GetRequestStream())
+                var responseFromServer = await response.Content.ReadAsStringAsync();
+                if (responseFromServer.Length > 0)
                 {
-                    dataStream.Write(byteArray, 0, byteArray.Length);
+                    DiscordConnectorPlugin.StaticLogger.LogDebug(
+                        $"DispatchRequest.{requestId}: Response from server: {responseFromServer}");
                 }
-
-                // Wait for a response to the web request
-                bool responseExpected = true;
-                WebResponse response;
-                try
+                else
                 {
-                    response = request.GetResponse();
-                    if (DiscordConnectorPlugin.StaticConfig.DebugHttpRequestResponse)
-                    {
-                        if (response is HttpWebResponse webResponse)
-                        {
-                            if (webResponse.StatusCode == HttpStatusCode.NoContent)
-                            {
-                                responseExpected = false;
-                            }
-
-                            DiscordConnectorPlugin.StaticLogger.LogDebug(
-                                $"DispatchRequest.{requestId}: Response Code: {webResponse.StatusCode}");
-                        }
-                        else
-                        {
-                            DiscordConnectorPlugin.StaticLogger.LogDebug(
-                                $"DispatchRequest.{requestId}: Response was not an HttpWebResponse");
-                        }
-                    }
+                    DiscordConnectorPlugin.StaticLogger.LogDebug(
+                        $"DispatchRequest.{requestId}: Empty response from server (normal)");
                 }
-                catch (WebException ex)
-                {
-                    DiscordConnectorPlugin.StaticLogger.LogError(
+            }
+        }
+        catch (Exception ex)
+        {
+            DiscordConnectorPlugin.StaticLogger.LogError(
                         $"DispatchRequest.{requestId}: Error getting web response: {ex}");
-                    return;
-                }
-
-                if (responseExpected)
-                {
-                    // Get the stream containing content returned by the server.
-                    using (Stream? dataStream = response.GetResponseStream())
-                    {
-                        if (dataStream == null)
-                        {
-                            DiscordConnectorPlugin.StaticLogger.LogError(
-                                $"DispatchRequest.{requestId}: Response stream is null");
-                            return;
-                        }
-
-                        // Open the stream using a StreamReader for easy access.
-                        using (StreamReader reader = new(dataStream))
-                        {
-                            // Read the content.
-                            string responseFromServer = reader.ReadToEnd();
-                            // Display the content.
-                            if (DiscordConnectorPlugin.StaticConfig.DebugHttpRequestResponse)
-                            {
-                                if (responseFromServer.Length > 0)
-                                {
-                                    DiscordConnectorPlugin.StaticLogger.LogDebug(
-                                        $"DispatchRequest.{requestId}: Response from server: {responseFromServer}");
-                                }
-                                else
-                                {
-                                    DiscordConnectorPlugin.StaticLogger.LogDebug(
-                                        $"DispatchRequest.{requestId}: Empty response from server (normal)");
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Close the response.
-                response.Close();
-            }
-            catch (Exception e)
-            {
-                DiscordConnectorPlugin.StaticLogger.LogWarning($"Error dispatching webhook: {e}");
-            }
-        }).ConfigureAwait(false);
+            return;
+        }
     }
 
     /// <summary>

--- a/DiscordConnector/DiscordConnector.csproj
+++ b/DiscordConnector/DiscordConnector.csproj
@@ -17,10 +17,10 @@
         <Optimize>true</Optimize>
     </PropertyGroup>
 
-    <Import Project="..\Environment.props" Condition="Exists('..\Environment.props')"/>
-    <Import Project="..\DoPrebuild.props" Condition="Exists('..\DoPrebuild.props')"/>
-    <Import Project="..\PublishSteps.targets" Condition="Exists('..\PublishSteps.targets')"/>
-    <Import Project="..\DeterminePaths.targets" Condition="Exists('..\DeterminePaths.targets')"/>
+    <Import Project="..\Environment.props" Condition="Exists('..\Environment.props')" />
+    <Import Project="..\DoPrebuild.props" Condition="Exists('..\DoPrebuild.props')" />
+    <Import Project="..\PublishSteps.targets" Condition="Exists('..\PublishSteps.targets')" />
+    <Import Project="..\DeterminePaths.targets" Condition="Exists('..\DeterminePaths.targets')" />
 
     <ItemGroup>
         <Reference Include="0Harmony">
@@ -38,10 +38,11 @@
         <Reference Include="BepInEx">
             <HintPath>$(BepInExPath)\core\BepInEx.dll</HintPath>
         </Reference>
-        <Reference Include="mscorlib"/>
+        <Reference Include="mscorlib" />
         <Reference Include="SoftReferenceableAssets">
             <HintPath>$(PublicizedAssembliesPath)\SoftReferenceableAssets_publicized.dll</HintPath>
         </Reference>
+        <Reference Include="System.Net.Http" />
         <Reference Include="UnityEngine">
             <HintPath>$(CorlibPath)\UnityEngine.dll</HintPath>
         </Reference>
@@ -78,16 +79,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Content Include="ILRepack.targets"/>
-        <Content Include="Metadata\DiscordConnector-Nexus.readme"/>
-        <Content Include="Metadata\icon.png"/>
-        <Content Include="Metadata\icon.svg"/>
-        <Content Include="Metadata\icon2.svg"/>
-        <Content Include="Metadata\icon3.svg"/>
-        <Content Include="Metadata\icon4.svg"/>
-        <Content Include="Metadata\manifest.json"/>
-        <Content Include="Metadata\README.md"/>
-        <Content Include="Metadata\thunderstore.toml"/>
+        <Content Include="ILRepack.targets" />
+        <Content Include="Metadata\DiscordConnector-Nexus.readme" />
+        <Content Include="Metadata\icon.png" />
+        <Content Include="Metadata\icon.svg" />
+        <Content Include="Metadata\icon2.svg" />
+        <Content Include="Metadata\icon3.svg" />
+        <Content Include="Metadata\icon4.svg" />
+        <Content Include="Metadata\manifest.json" />
+        <Content Include="Metadata\README.md" />
+        <Content Include="Metadata\thunderstore.toml" />
     </ItemGroup>
 
     <ItemGroup>
@@ -99,14 +100,14 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="JotunnLib" Version="2.26.1"/>
-        <PackageReference Include="LiteDB" Version="5.0.21"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="System.Buffers" Version="4.6.1"/>
+        <PackageReference Include="JotunnLib" Version="2.26.1" />
+        <PackageReference Include="LiteDB" Version="5.0.21" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="System.Buffers" Version="4.6.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\DiscordConnector.Common\DiscordConnector.Common.csproj"/>
+        <ProjectReference Include="..\DiscordConnector.Common\DiscordConnector.Common.csproj" />
     </ItemGroup>
 
 </Project>

--- a/DiscordConnector/Plugin.cs
+++ b/DiscordConnector/Plugin.cs
@@ -17,7 +17,7 @@ namespace DiscordConnector;
 public class DiscordConnectorPlugin : BaseUnityPlugin
 {
     internal const string ModName = "DiscordConnector";
-    internal const string ModVersion = "3.1.1";
+    internal const string ModVersion = "3.1.2";
     internal const string Author = "nwesterhausen";
     private const string ModGuid = Author + "." + ModName;
     internal const string LegacyConfigPath = "games.nwest.valheim.discordconnector";


### PR DESCRIPTION
This PR is to fix #373. It fixes the prefix issue, and I haven't noticed any newly introduced problems with this solution. That being said, I haven't done extensive testing.

The `WebRequest` class is being discouraged by msft in favor of the `HttpClient` class ([see "Remarks" section](https://learn.microsoft.com/en-us/dotnet/api/system.net.webrequest?view=netframework-4.8.1)). This change replaces `WebRequest` with `HttpClient`.

I saw this issue on a friend's https://github.com/brianmiller/phvalheim-server server, but I did not see it on my own https://github.com/mbround18/valheim-docker server. I theorize it comes down to installing the dedicated server with the addition of this argument `+@sSteamCmdForcePlatformType linux`. I believe the mbround18/valheim-docker container is using Debian 13 while phvalheim is on Debian 11.